### PR TITLE
poolclass as a resolvable option

### DIFF
--- a/asphalt/sqlalchemy/component.py
+++ b/asphalt/sqlalchemy/component.py
@@ -70,8 +70,7 @@ class SQLAlchemyComponent(Component):
     def configure_engine(cls, url: Union[str, URL, Dict[str, Any]] = None,
                          bind: Union[Connection, Engine] = None, session: Dict[str, Any] = None,
                          ready_callback: Union[Callable[[Engine, sessionmaker], Any], str] = None,
-                         poolclass: Union[str, Pool] = None,
-                         **engine_args):
+                         poolclass: Union[str, Pool] = None, **engine_args):
         """
         Create an engine and selectively apply certain hacks to make it Asphalt friendly.
 
@@ -95,6 +94,7 @@ class SQLAlchemyComponent(Component):
                 url = make_url(url)
             elif url is None:
                 raise TypeError('both "url" and "bind" cannot be None')
+
             if isinstance(poolclass, str):
                 poolclass = resolve_reference(poolclass)
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -27,7 +27,7 @@ They ensure that any changes made to the database are rolled back at the end of 
 
     import pytest
     from asphalt.core import ContainerComponent, Context
-    from asphalt.sqlalchemy.utils import clear_database
+    from asphalt.sqlalchemy import clear_database
 
     from yourapp.component import ApplicationComponent
     from yourapp.models import Base, Person
@@ -37,7 +37,7 @@ They ensure that any changes made to the database are rolled back at the end of 
     def root_context(event_loop):
         # This is the top level context that remains open throughout the testing session
         with Context() as root_ctx:
-            yield root_ctx
+            yield context
 
 
     @pytest.fixture(scope='session')
@@ -73,6 +73,6 @@ They ensure that any changes made to the database are rolled back at the end of 
             # Make sure that no data sent to the database during the tests is ever persisted
             connection = context.sql.bind.begin()
             yield ctx
-            connection.transaction.close()
+            connection.close()
 
 .. _py.test: http://pytest.org

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -73,6 +73,6 @@ They ensure that any changes made to the database are rolled back at the end of 
             # Make sure that no data sent to the database during the tests is ever persisted
             connection = context.sql.bind.begin()
             yield ctx
-            connection.close()
+            connection.transaction.close()
 
 .. _py.test: http://pytest.org

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -27,7 +27,7 @@ They ensure that any changes made to the database are rolled back at the end of 
 
     import pytest
     from asphalt.core import ContainerComponent, Context
-    from asphalt.sqlalchemy import clear_database
+    from asphalt.sqlalchemy.utils import clear_database
 
     from yourapp.component import ApplicationComponent
     from yourapp.models import Base, Person
@@ -37,7 +37,7 @@ They ensure that any changes made to the database are rolled back at the end of 
     def root_context(event_loop):
         # This is the top level context that remains open throughout the testing session
         with Context() as root_ctx:
-            yield context
+            yield root_ctx
 
 
     @pytest.fixture(scope='session')

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -29,7 +29,7 @@ def executor():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(('poolclass'), [(None), ('sqlalchemy.pool:StaticPool')])
+@pytest.mark.parametrize('poolclass', [None, 'sqlalchemy.pool:StaticPool'])
 async def test_component_start(poolclass):
     """Test that the component creates all the expected resources."""
     component = SQLAlchemyComponent(url='sqlite:///:memory:', poolclass=poolclass)


### PR DESCRIPTION
1. `clear_database` is importable from `asphalt.sqlalchemy.utils` not `asphalt.sqlalchemy`.
2. the `root_context` fixture should yield `root_ctx` not `context`.
